### PR TITLE
Checking env vars before aborting builds

### DIFF
--- a/roll.py
+++ b/roll.py
@@ -1,6 +1,7 @@
 import os
 import requests
 import json
+import sys
 
 def abort(build, base_url, app_slug, request_headers):
     payload = json.dumps({
@@ -16,6 +17,11 @@ def abort(build, base_url, app_slug, request_headers):
     else:
         print('Successfully aborted workflow {} with slug {}'.format(build['triggered_workflow'], build['slug']))
         return True
+def check_vars(env_vars):
+    for var in env_vars:
+        if not var:
+            print('{} is empty, exiting.'.format(var))
+            sys.exit(1)
 
 def main():
     rolled_build_slugs_list = []
@@ -26,6 +32,8 @@ def main():
     app_slug = os.environ.get('app_slug')
     build_slug = os.environ.get('build_slug')
     branch = os.environ.get('branch')
+    env_vars = [branch, build_slug, app_slug, base_url, token]
+    check_vars(token)
 
     running_builds_url = 'https://{}/apps/{}/builds?sort_by=created_at&branch={}&status=0'.format(base_url, app_slug, branch)
     print('URL: {}'.format(running_builds_url))

--- a/roll.py
+++ b/roll.py
@@ -33,7 +33,7 @@ def main():
     build_slug = os.environ.get('build_slug')
     branch = os.environ.get('branch')
     env_vars = [branch, build_slug, app_slug, base_url, token]
-    check_vars(token)
+    check_vars(env_vars)
 
     running_builds_url = 'https://{}/apps/{}/builds?sort_by=created_at&branch={}&status=0'.format(base_url, app_slug, branch)
     print('URL: {}'.format(running_builds_url))

--- a/roll.py
+++ b/roll.py
@@ -18,10 +18,15 @@ def abort(build, base_url, app_slug, request_headers):
         print('Successfully aborted workflow {} with slug {}'.format(build['triggered_workflow'], build['slug']))
         return True
 def check_vars(env_vars):
+    missing_vars = []
     for var in env_vars:
         if not var:
-            print('{} is empty, exiting.'.format(var))
-            sys.exit(1)
+            missing_vars.append(var)
+    
+    if(len(missing_vars) > 0):
+        for var in missing_vars:
+            print('{} is empty'.format(var))
+        sys.exit(1)
 
 def main():
     rolled_build_slugs_list = []


### PR DESCRIPTION
Fixing bug where branch name was passed in as empty which ended up rolling builds it shouldn't have
<img width="741" alt="Screen Shot 2022-03-21 at 11 37 44 AM" src="https://user-images.githubusercontent.com/87317545/159296607-41e94e9c-431e-466b-8ed1-b8b81c739414.png">